### PR TITLE
Install iputils-ping

### DIFF
--- a/technical-evaluation-stack/gitpod/Dockerfile
+++ b/technical-evaluation-stack/gitpod/Dockerfile
@@ -14,7 +14,7 @@ RUN apt update
 RUN apt install -y apt-utils software-properties-common apt-transport-https sudo \
     psmisc lsb-release tmux nano wget curl telnet gnupg build-essential gdb git gitk \
     cmake cmake-curses-gui libedit-dev libxml2-dev autoconf locales gdebi terminator meld \
-    dos2unix bash-completion
+    dos2unix bash-completion iputils-ping
 
 # Set the locale
 RUN locale-gen en_US.UTF-8


### PR DESCRIPTION
The `ping` is quite useful in the command line to quickly create long running commands or debug network problems.